### PR TITLE
Add Flask dashboard and Excel parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # merchant-data
-Data reporting for TRC merchants
+
+This repository contains a simple Flask dashboard for viewing merchant data from an uploaded Excel workbook. The workbook should contain two sheets named **"merchant list"** and **"offs list"**. Statistics are calculated from the merchant list sheet.
+
+## Requirements
+
+The project relies only on the Python standard library and `flask`. If `flask` is not available in your environment, install it locally.
+
+## Running the app
+
+```
+python3 app/main.py
+```
+
+Then open `http://localhost:5000` in your browser to upload a workbook and view the dashboard.
+
+## Limitations
+
+A minimal Excel reader is included (`simple_xlsx.py`). It supports basic cell types but may not handle all Excel features. For large workbooks, performance may be limited.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,93 @@
+from flask import Flask, request, redirect, url_for, render_template, flash
+from simple_xlsx import read_workbook
+
+app = Flask(__name__)
+app.secret_key = 'secret'
+
+# Store uploaded data in memory
+dashboard_data = {}
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    global dashboard_data
+    file = request.files.get('file')
+    if not file or file.filename == '':
+        flash('No file selected')
+        return redirect(url_for('index'))
+    path = '/tmp/upload.xlsx'
+    file.save(path)
+    try:
+        dashboard_data = read_workbook(path)
+    except Exception as e:
+        flash(f'Failed to parse file: {e}')
+        dashboard_data = {}
+    return redirect(url_for('dashboard'))
+
+
+def _compute_stats(rows):
+    stats = {
+        'total': len(rows),
+        'deal_stage_counts': {},
+        'region_counts': {},
+        'lost_count': 0,
+    }
+    for row in rows:
+        stage = row.get('deal_stage', 'Unknown')
+        region = row.get('region', 'Unknown')
+        stats['deal_stage_counts'][stage] = stats['deal_stage_counts'].get(stage, 0) + 1
+        stats['region_counts'][region] = stats['region_counts'].get(region, 0) + 1
+        if stage.lower() in {'lost', 'churn', 'churned'}:
+            stats['lost_count'] += 1
+    stats['lost_rate'] = (stats['lost_count'] / stats['total']) * 100 if stats['total'] else 0
+    return stats
+
+
+@app.route('/dashboard')
+def dashboard():
+    merchant_data = dashboard_data.get('merchant list', [])
+    offs_data = dashboard_data.get('offs list', [])
+    stats = _compute_stats(merchant_data)
+    return render_template(
+        'dashboard.html',
+        merchant_data=merchant_data,
+        offs_data=offs_data,
+        stats=stats,
+    )
+
+
+@app.route('/ask', methods=['POST'])
+def ask():
+    merchant_data = dashboard_data.get('merchant list', [])
+    question = request.form.get('question', '')
+    answer = _answer_question(merchant_data, question)
+    return {'answer': answer}
+
+
+def _answer_question(rows, question: str) -> str:
+    if not rows:
+        return 'No data loaded.'
+    q = question.lower()
+    if 'live' in q:
+        region = _extract_region(rows, q)
+        count = sum(1 for r in rows if r.get('deal_stage', '').lower() == 'live' and (not region or r.get('region', '').lower() == region.lower()))
+        return f'{count} retailers are live{f" in {region}" if region else ""}.'
+    if 'lost' in q and '2024' in q:
+        count = sum(1 for r in rows if r.get('deal_stage', '').lower() == 'lost' and '2024' in str(r.get('lost_date', '')))
+        return f'{count} retailers lost in 2024.'
+    return 'Question not recognized.'
+
+
+def _extract_region(rows, text: str):
+    regions = {r.get('region', '') for r in rows if r.get('region')}
+    for region in regions:
+        if region.lower() in text:
+            return region
+    return None
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/simple_xlsx.py
+++ b/app/simple_xlsx.py
@@ -1,0 +1,74 @@
+import zipfile
+import xml.etree.ElementTree as ET
+from typing import List, Dict
+
+NS_MAIN = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main'
+NS_REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+
+def _read_shared_strings(z: zipfile.ZipFile) -> List[str]:
+    shared = []
+    if 'xl/sharedStrings.xml' in z.namelist():
+        root = ET.fromstring(z.read('xl/sharedStrings.xml'))
+        for si in root.iter(f'{{{NS_MAIN}}}t'):
+            shared.append(si.text or '')
+    return shared
+
+
+def _sheet_paths(z: zipfile.ZipFile) -> Dict[str, str]:
+    if 'xl/workbook.xml' not in z.namelist():
+        return {}
+    root = ET.fromstring(z.read('xl/workbook.xml'))
+    sheet_map = {}
+    for sheet in root.find(f'{{{NS_MAIN}}}sheets'):
+        name = sheet.attrib.get('name')
+        r_id = sheet.attrib.get(f'{{{NS_REL}}}id')
+        sheet_map[r_id] = name
+
+    paths = {}
+    if 'xl/_rels/workbook.xml.rels' in z.namelist():
+        rels = ET.fromstring(z.read('xl/_rels/workbook.xml.rels'))
+        for rel in rels:
+            r_id = rel.attrib.get('Id')
+            target = rel.attrib.get('Target')
+            if r_id in sheet_map:
+                paths[sheet_map[r_id]] = 'xl/' + target
+    return paths
+
+
+def _read_sheet(z: zipfile.ZipFile, path: str, shared: List[str]) -> List[List[str]]:
+    rows = []
+    root = ET.fromstring(z.read(path))
+    for row in root.iter(f'{{{NS_MAIN}}}row'):
+        row_data = []
+        for c in row.iter(f'{{{NS_MAIN}}}c'):
+            cell_type = c.attrib.get('t')
+            v = c.find(f'{{{NS_MAIN}}}v')
+            value = v.text if v is not None else ''
+            if cell_type == 's' and value.isdigit():
+                idx = int(value)
+                if 0 <= idx < len(shared):
+                    value = shared[idx]
+            row_data.append(value)
+        rows.append(row_data)
+    return rows
+
+
+def read_workbook(path: str) -> Dict[str, List[Dict[str, str]]]:
+    """Return workbook sheets as list of dicts keyed by sheet name."""
+    with zipfile.ZipFile(path) as z:
+        shared = _read_shared_strings(z)
+        sheet_paths = _sheet_paths(z)
+        data = {}
+        for name, sheet_path in sheet_paths.items():
+            rows = _read_sheet(z, sheet_path, shared)
+            if not rows:
+                data[name] = []
+                continue
+            headers = rows[0]
+            sheet_data = []
+            for r in rows[1:]:
+                item = {headers[i]: r[i] if i < len(r) else '' for i in range(len(headers))}
+                sheet_data.append(item)
+            data[name] = sheet_data
+        return data

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+    <title>Dashboard</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+    <h1>Merchant Dashboard</h1>
+    <div>
+        <form id="ask-form" method="post" action="{{ url_for('ask') }}">
+            <input type="text" name="question" id="question" placeholder="Ask a question">
+            <button type="submit">Ask</button>
+        </form>
+        <p id="answer"></p>
+    </div>
+    <h2>Stats</h2>
+    <p>Total merchants: {{ stats.total }}</p>
+    <p>Lost rate: {{ '%.2f' % stats.lost_rate }}%</p>
+    <h3>Deal Stage Counts</h3>
+    <ul>
+        {% for stage, count in stats.deal_stage_counts.items() %}
+            <li>{{ stage }}: {{ count }}</li>
+        {% endfor %}
+    </ul>
+    <h3>Region Counts</h3>
+    <ul>
+        {% for region, count in stats.region_counts.items() %}
+            <li>{{ region }}: {{ count }}</li>
+        {% endfor %}
+    </ul>
+    <script>
+        $('#ask-form').on('submit', function(e){
+            e.preventDefault();
+            $.post($(this).attr('action'), $(this).serialize(), function(data){
+                $('#answer').text(data.answer);
+            });
+        });
+    </script>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+    <title>Merchant Dashboard</title>
+</head>
+<body>
+    <h1>Upload Merchant Excel</h1>
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <ul>
+          {% for message in messages %}
+            <li>{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+    <form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data">
+        <input type="file" name="file">
+        <input type="submit" value="Upload">
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple Flask dashboard for merchant reporting
- implement minimal XLSX parser without external deps
- add HTML templates for upload and reporting
- document usage in README

## Testing
- `ruff check app`
- `pyright app` *(fails: Import "flask" could not be resolved)*
- `pip install flask` *(fails: Tunnel connection failed 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_686f9f4a2af48320ac90e23626a69b1b